### PR TITLE
Examples: Python3

### DIFF
--- a/example/Makefile
+++ b/example/Makefile
@@ -1,7 +1,7 @@
 
 example: example.F example.v example_extra.f
 	Forthon --no2underscores -g example example_extra.f
-	mv build/*/*/examplepy.so .
+	mv build/*/*/*.so .
 	python example.py
 
 clean:

--- a/example/Makefile
+++ b/example/Makefile
@@ -1,6 +1,7 @@
+FORTHON=Forthon
 
 example: example.F example.v example_extra.f
-	Forthon --no2underscores -g example example_extra.f
+	$(FORTHON) --no2underscores -g example example_extra.f
 	mv build/*/*/*.so .
 	python example.py
 

--- a/example/example.py
+++ b/example/example.py
@@ -1,85 +1,85 @@
 from Forthon import *
 from examplepy import *
 
-print 'Testing basic call to fortran routine'
+print('Testing basic call to fortran routine')
 testsub1(5,6.)
-print 'Should be'
-print ' ii,aa =            5   6.00000000000000'
-print ''
+print('Should be')
+print(' ii,aa =            5   6.00000000000000')
+print('')
 
-print 'Testing of setting variables in python and fortran'
-print example.i,example.a,example.d
-print 'Should be'
-print '3 7.0 [ 10.  10.  10.]'
-print ''
+print('Testing of setting variables in python and fortran')
+print(example.i,example.a,example.d)
+print('Should be')
+print('3 7.0 [ 10.  10.  10.]')
+print('')
 example.i = 7
 example.a = 8.
 example.d = [3.1415926,2.99792458e+8,2.718281828459]
-print example.i,example.a,example.d
-print 'Should be'
-print '7 8.0 [  3.14159260e+00   2.99792458e+08   2.71828183e+00]'
-print ''
+print(example.i,example.a,example.d)
+print('Should be')
+print('7 8.0 [  3.14159260e+00   2.99792458e+08   2.71828183e+00]')
+print('')
 testsub2(5,6.,[-1.,0.,1.])
-print 'Should be'
-print ' i,a =             7   8.00000000000000'
-print ' d =    3.14159260000000        299792458.000000        2.71828182845900'
-print ''
-print example.i,example.a,example.d
-print 'Should be'
-print '5 6.0 [-1.  0.  1.]'
-print ''
+print('Should be')
+print(' i,a =             7   8.00000000000000')
+print(' d =    3.14159260000000        299792458.000000        2.71828182845900')
+print('')
+print(example.i,example.a,example.d)
+print('Should be')
+print('5 6.0 [-1.  0.  1.]')
+print('')
 
-print 'Testing operating on dynamic derived type'
+print('Testing operating on dynamic derived type')
 testsub3(5,6.,4)
-print example.t2.j,example.t2.b,example.t2.y
-print 'Should be'
-print '5 6.0 [ 1.  1.  1.  1.  1.]'
-print ''
+print(example.t2.j,example.t2.b,example.t2.y)
+print('Should be')
+print('5 6.0 [ 1.  1.  1.  1.  1.]')
+print('')
 
-print 'Testing deferred-shape arrays'
+print('Testing deferred-shape arrays')
 example.z = [1,2,3]
-print example.z
-print 'Should be'
-print '[ 1.  2.  3.]'
-print ''
+print(example.z)
+print('Should be')
+print('[ 1.  2.  3.]')
+print('')
 testsub5()
-print 'Should be'
-print ' z =    1.00000000000000        2.00000000000000        3.00000000000000'
+print('Should be')
+print(' z =    1.00000000000000        2.00000000000000        3.00000000000000')
 
-print 'Passing derived types into fortran subrotuines'
+print('Passing derived types into fortran subrotuines')
 example.t2.j = 20
 testsub6(example.t2)
-print 'Should be'
-print ' t%j =           20'
-print ''
+print('Should be')
+print(' t%j =           20')
+print('')
 
 
-print 'Testing array assignment of the form pkg.x = x'
+print('Testing array assignment of the form pkg.x = x')
 xx = fzeros((3,2),'d')
 example.xxx = xx
 xx[1,1] = 1
-print 'The following two arrays should be identical, since only pointer'
-print 'referencing is done if the RHS array has fortran ordering.'
-print xx
-print example.xxx
+print('The following two arrays should be identical, since only pointer')
+print('referencing is done if the RHS array has fortran ordering.')
+print(xx)
+print(example.xxx)
 xx = zeros((3,2),'d')
 example.xxx = xx
 xx[1,1] = 1
-print 'The following two arrays should be different, since a copy is done'
-print 'if the RHS array has C ordering.'
-print xx
-print example.xxx
-print ''
+print('The following two arrays should be different, since a copy is done')
+print('if the RHS array has C ordering.')
+print(xx)
+print(example.xxx)
+print('')
 
-print 'Testing set and get actions on variables'
-print 'The text "action1 is being set to 1" should be printed below'
+print('Testing set and get actions on variables')
+print('The text "action1 is being set to 1" should be printed below')
 example.action1 = 1
-print 'The test "action1 is being get" should be printed below'
+print('The test "action1 is being get" should be printed below')
 example.action1
-print 'The text "Type2 xx is being set to 3.1415926" should be printed below'
+print('The text "Type2 xx is being set to 3.1415926" should be printed below')
 example.action2.xx = 3.1415926
-print 'The test "Type2 xx is being get" should be printed below'
+print('The test "Type2 xx is being get" should be printed below')
 example.action2.xx
-print ''
+print('')
 
-print 'Tests complete'
+print('Tests complete')

--- a/example2/Makefile
+++ b/example2/Makefile
@@ -1,6 +1,7 @@
+FORTHON=Forthon
 
 example2: example2.F example2.v
-	Forthon --nowritemodules example2
+	$(FORTHON) --nowritemodules example2
 	mv build/*/*/*.so .
 	python example2.py
 

--- a/example2/Makefile
+++ b/example2/Makefile
@@ -1,7 +1,7 @@
 
 example2: example2.F example2.v
 	Forthon --nowritemodules example2
-	mv build/*/*/example2py.so .
+	mv build/*/*/*.so .
 	python example2.py
 
 clean:

--- a/example2/example2.py
+++ b/example2/example2.py
@@ -1,21 +1,21 @@
 import example2py
 from example2py import *
 
-print 'Testing basic call to fortran routine'
+print('Testing basic call to fortran routine')
 testsub2(5,6.)
-print example2.t1.j,example2.t1.b
-print 'Should be'
-print '5 6.0'
-print ''
-print example2.t2.j,example2.t2.b
-print 'Should be'
-print '25 36.0'
-print ''
+print(example2.t1.j,example2.t1.b)
+print('Should be')
+print('5 6.0')
+print('')
+print(example2.t2.j,example2.t2.b)
+print('Should be')
+print('25 36.0')
+print('')
 
 testsub3()
 try:
-  print example2.t2
+  print(example2.t2)
 except example2py.error:
-  print "printing t2 produced the correct error since it is unassociated"
+  print("printing t2 produced the correct error since it is unassociated")
 
-print 'Tests complete'
+print('Tests complete')

--- a/simpleexample/Makefile
+++ b/simpleexample/Makefile
@@ -1,6 +1,7 @@
+FORTHON=Forthon
 
 example: example.F example.v
-	Forthon example
+	$(FORTHON) example
 	mv build/*/*/*.so .
 	python example.py
 

--- a/simpleexample/example.py
+++ b/simpleexample/example.py
@@ -1,6 +1,6 @@
 from Forthon import *
 from examplepy import *
 
-print "Before setsqrt, x = ",example.x
+print("Before setsqrt, x = ",example.x)
 setsqrt(10.)
-print "After setsqrt, x = ",example.x
+print("After setsqrt, x = ",example.x)


### PR DESCRIPTION
This pull-request fixes some of the issues reported with Python3 in the examples (see #7).
- convert scripts to be python 3 compatible (`2to3`)
- move `.so` files as in `simpleexample` since the library name seems to be different in python 3 compiles
- backwards compatible with python 2
