### PR TITLE
Close #7 Continous Integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,12 @@ matrix:
 
 sudo: false
 
+addons:
+  apt:
+    packages:
+      # gfortran is needed to build the examples
+      - gfortran
+
 env:
   matrix:
     - USE_PIP=ON
@@ -33,3 +39,21 @@ script:
     else
       python setup.py install;
     fi
+  # Python3 test
+  - FORTHON_FOUND=$(which Forthon >/dev/null && { echo 0; } || { echo 1; })
+  - if [ $FORTHON_FOUND -eq 0 ]; then
+      export FORTHON_CMD=Forthon;
+    else
+      echo "Python 3 - overwriting Forthon executable with Forthon3";
+      export FORTHON_CMD=Forthon3;
+    fi
+  - which $FORTHON_CMD
+  # now build some examples
+  - cd example
+  - make FORTHON=$FORTHON_CMD
+  # broken legacy example:
+  # - cd ../example2
+  # - make FORTHON=$FORTHON_CMD
+  - cd ../simpleexample
+  - make FORTHON=$FORTHON_CMD
+  - cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,35 @@
+language: python
+
+python:
+ - "2.6"
+ - "2.7"
+ - "3.4"
+ - "3.5"
+ - "nightly"
+ - "pypy"
+ - "pypy3"
+
+matrix:
+  allow_failures:
+    - python: nightly
+    - python: "pypy"
+    - python: "pypy3"
+
+sudo: false
+
+env:
+  matrix:
+    - USE_PIP=ON
+    - USE_PIP=OFF
+
+script:
+  # install latest release from pip
+  # .. or install from source
+  #
+  # note: since this is executed in a virtualenv
+  #       we can not add "--user"
+  - if [ "$USE_PIP" == "ON" ]; then
+      pip install Forthon;
+    else
+      python setup.py install;
+    fi

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 See License.txt for license information.
 ============================================================================
 
+[![Build Status](https://travis-ci.org/dpgrote/Forthon.svg?branch=master)](https://travis-ci.org/dpgrote/Forthon)
+
 Forthon generates links between Fortran95 and Python. Python is a high level,
 object oriented, interactive and scripting language that allows a flexible
 and versatile interface to computational tools. The Forthon package generates


### PR DESCRIPTION
Closes #7 by adding the free continous-integration service travis-ci.

To activate you just need to
- merge this pull request (which adds a `.travis.yml` file with test instructions)
- log into https://travis-ci.org/ with your github account
- synchronize your public repositories and activate `Forthon` [in your profile](https://travis-ci.org/profile)

And you are set :)

Each of your new commits will then be tested against various versions of Python!

Note: I renamed `README` to `README.md` which is a normal text-file convention on GitHub to activate [Markdown support](https://help.github.com/articles/about-writing-and-formatting-on-github/) which allows to add links, formatting and images. The reason for that is so we can add the latest "status badge" ([![Build Status](https://travis-ci.org/ax3l/Forthon.svg?branch=topic-travisCI)](https://travis-ci.org/ax3l/Forthon)) of the repository's build in it.

Python 3 example testing depends on the updates provided in #8.
