### PR TITLE
Examples: Make $(PYTHON) a Makefile Var

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,6 @@ matrix:
     - python: nightly
     - python: "pypy"
     - python: "pypy3"
-    # Python 3.X & PIP is currently broken and needs a fix
-    - env: USE_PIP=ON
-      python: "3.4"
-    - env: USE_PIP=ON
-      python: "3.5"
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 
 python:
- - "2.6"
  - "2.7"
  - "3.4"
  - "3.5"
@@ -11,9 +10,15 @@ python:
 
 matrix:
   allow_failures:
+    # those "upcoming" python versions are informational
     - python: nightly
     - python: "pypy"
     - python: "pypy3"
+    # Python 3.X & PIP is currently broken and needs a fix
+    - env: USE_PIP=ON
+      python: "3.4"
+    - env: USE_PIP=ON
+      python: "3.5"
 
 sudo: false
 

--- a/example/Makefile
+++ b/example/Makefile
@@ -1,9 +1,10 @@
 FORTHON=Forthon
+PYTHON=python
 
 example: example.F example.v example_extra.f
 	$(FORTHON) --no2underscores -g example example_extra.f
 	mv build/*/*/*.so .
-	python example.py
+	$(PYTHON) example.py
 
 clean:
 	rm -rf build examplepy.so

--- a/example2/Makefile
+++ b/example2/Makefile
@@ -1,9 +1,10 @@
 FORTHON=Forthon
+PYTHON=python
 
 example2: example2.F example2.v
 	$(FORTHON) --nowritemodules example2
 	mv build/*/*/*.so .
-	python example2.py
+	$(PYTHON) example2.py
 
 clean:
 	rm -rf build example2py.so

--- a/simpleexample/Makefile
+++ b/simpleexample/Makefile
@@ -1,9 +1,10 @@
 FORTHON=Forthon
+PYTHON=python
 
 example: example.F example.v
 	$(FORTHON) example
 	mv build/*/*/*.so .
-	python example.py
+	$(PYTHON) example.py
 
 clean:
 	rm -rf build *.so


### PR DESCRIPTION
Follow-up to the annotation in #8 to make `python` itself a variable in the example Makefiles, too.

I did ~~hide~~ remove the broken Python 2.6 support ~~and the broken PIP3 support~~ (_fixed_ after rebase) for now ~~so we can fix this an other time~~.
