### PR TITLE
Readme: Format Headlines, Link License

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
-============================================================================
-See License.txt for license information.
-============================================================================
+# Forthon
 
 [![Build Status](https://travis-ci.org/dpgrote/Forthon.svg?branch=master)](https://travis-ci.org/dpgrote/Forthon)
 [![Supported Python versions](https://img.shields.io/pypi/pyversions/Forthon.svg)](https://pypi.python.org/pypi/Forthon)
 [![PyPI version](https://img.shields.io/pypi/v/Forthon.svg)](https://pypi.python.org/pypi/Forthon)
 [![PyPI downloads](https://img.shields.io/pypi/dm/Forthon.svg)](https://pypi.python.org/pypi/Forthon)
-[![PyPI license](https://img.shields.io/pypi/l/Forthon.svg)](https://pypi.python.org/pypi/Forthon)
+[![PyPI license](https://img.shields.io/pypi/l/Forthon.svg)](License.txt)
 
 Forthon generates links between Fortran95 and Python. Python is a high level,
 object oriented, interactive and scripting language that allows a flexible
@@ -17,7 +15,13 @@ where the computationally intensive parts of a code can be written in
 efficient Fortran, and the high level controlling code can be written in the
 much more versatile Python language.
 
-Release Notes:
+
+## License
+
+See [License.txt](License.txt) for license information.
+
+
+## Release Notes
 
 0.8.20: April 15, 2016
  - Added Forthon3 to MANIFEST


### PR DESCRIPTION
This pull request adds native Markdown formatting to the three sections in the `README.md` and links to the `License.txt` file so users can "click" on it.
