### PR TITLE
setup.py: license string

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -85,6 +85,7 @@ setup (name = "Forthon",
        version = version,
        author = 'David P. Grote',
        author_email = "DPGrote@lbl.gov",
+       license = "BSD-3-Clause-LLNL",
        url = "http://hifweb.lbl.gov/Forthon",
        description = "Fortran95 wrapper/code development package",
        long_description = """


### PR DESCRIPTION
Add the according license string to `setup.py` so PyPI and the README.md badge [![PyPI license](https://img.shields.io/pypi/l/Forthon.svg)](License.txt) can detect the according license.

Works well for the similar `BSD-3-Clause-LBNL` license in [openPMD-viewer](https://github.com/openPMD/openPMD-viewer/blob/74d8b3d0a106b3059360af0ead0a8fd479dfea6a/setup.py#L34).
