### PR TITLE
Compatibility python 2.6/ Avoid type error IBM BGQ

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,8 +30,13 @@ version = '0.8.23'
 try:
     # --- In python3, check_output returns a byte string that needs to be decoded to get the string.
     # --- The decode method is mostly harmless in python2.
-    bcommithash = subprocess.check_output('git log -n 1 --pretty=%h',stderr=subprocess.STDOUT,shell=True).strip()
-    commithash = bcommithash.decode()
+    bcommithash =subprocess.Popen(['git log -n 1 --pretty=%h'],shell=True,stderr=subprocess.PIPE,stdout=subprocess.PIPE).communicate()[0].strip()
+    commithash=bcommithash.decode()
+except subprocess.CalledProcessError:
+    # --- This version was obtained from a non-git distrobution. Use the
+    # --- saved commit hash from the release.
+    # --- This is automatically updated by version.py.
+    commithash = 'f3ecb8e'
 except subprocess.CalledProcessError:
     # --- This version was obtained from a non-git distrobution. Use the
     # --- saved commit hash from the release.

--- a/source/Forthon.h
+++ b/source/Forthon.h
@@ -668,7 +668,7 @@ static int Forthon_setscalarinteger(ForthonObject *self,PyObject *value,
     PyErr_SetString(PyExc_TypeError, "Cannot delete the attribute");
     return -1;}
   /* This will convert floats to ints if needed */
-  lv = PyLong_AsLong(value);
+  lv = PyInt_AsLong(value);
   if (!PyErr_Occurred()) {
     if (fscalar->setaction != NULL) {
       if (self->fobj == NULL) fscalar->setaction(&lv);


### PR DESCRIPTION
Dear Dave, 

Here is the pull request for enabling the use of Forthon with python 2.6 and avoiding type errors with C Long on IBM BGQ.  

Best, 

Henri